### PR TITLE
Changed Terms section to use Description Lists and to reference the ModSpec

### DIFF
--- a/standard_template/standard/clause_4_terms_and_definitions.adoc
+++ b/standard_template/standard/clause_4_terms_and_definitions.adoc
@@ -1,7 +1,12 @@
 == Terms and Definitions
 This document uses the terms defined in Sub-clause 5.3 of [OGC 06-121r8], which is based on the ISO/IEC Directives, Part 2, Rules for the structure and drafting of International Standards. In particular, the word “shall” (not “must”) is the verb form used to indicate a requirement to be strictly followed to conform to this standard.
 
+This document also uses terms defined in the OGC Standard for Modular specifications (https://portal.opengeospatial.org/files/?artifact_id=34762[OGC 08-131r3]), also known as the 'ModSpec'. The definitions of terms such as standard, specification, requirement, and conformance test are provided in the ModSpec.
+
 For the purposes of this document, the following additional terms and definitions apply.
 
-=== *term name*
+term name::
+text of the definition
+
+term name::
 text of the definition


### PR DESCRIPTION
Updated the Terms section with a reference to the Mod Spec, as per a recent OAB directive.

Also included change to Description Lists as proposed by @jyutzler in PR https://github.com/opengeospatial/templates/pull/15